### PR TITLE
ghidra: fix minimum JDK version

### DIFF
--- a/bucket/ghidra.json
+++ b/bucket/ghidra.json
@@ -3,10 +3,10 @@
     "description": "a software reverse engineering (SRE) framework",
     "homepage": "https://ghidra-sre.org",
     "license": "Apache-2.0",
-    "notes": "Ghidra requires JDK 17 on the PATH to run.",
+    "notes": "Ghidra requires JDK 21 on the PATH to run.",
     "extract_dir": "ghidra_11.3.1_PUBLIC",
     "suggest": {
-        "JDK": "java/temurin17-jdk"
+        "JDK": "java/temurin21-jdk"
     },
     "architecture": {
         "64bit": {


### PR DESCRIPTION
as of [this commit](https://github.com/NationalSecurityAgency/ghidra/commit/966e6fddf3e77e21fac27a9ecf79976066443bdf) during the development of Ghidra 11.2, the minimum JDK version was bumped from 17 to 21.. I just noticed that the Scoop manifest for this one was not updated.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
